### PR TITLE
Prefixes

### DIFF
--- a/src/main/java/com/statemachinesystems/envy/Parameter.java
+++ b/src/main/java/com/statemachinesystems/envy/Parameter.java
@@ -69,6 +69,11 @@ public class Parameter {
         return name.toLowerCase().replaceAll("_", ".");
     }
 
+    public Parameter join(Parameter other) {
+        return new Parameter(
+                String.format("%s_%s", this.asEnvironmentVariableName(), other.asEnvironmentVariableName()));
+    }
+
     @Override
     public String toString() {
         return this.asEnvironmentVariableName();

--- a/src/main/java/com/statemachinesystems/envy/Prefix.java
+++ b/src/main/java/com/statemachinesystems/envy/Prefix.java
@@ -1,0 +1,15 @@
+package com.statemachinesystems.envy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applies a prefix to all parameter names in a configuration interface.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Prefix {
+    String value();
+}

--- a/src/test/java/com/statemachinesystems/envy/ParameterTest.java
+++ b/src/test/java/com/statemachinesystems/envy/ParameterTest.java
@@ -184,4 +184,11 @@ public class ParameterTest {
     public void rejectsLeadingUnderscoreInName() {
         new Parameter("_BAR");
     }
+
+    @Test
+    public void joinsTwoParameters() {
+        Parameter prefix = new Parameter("prefix");
+        Parameter suffix = new Parameter("suffix");
+        assertThat(prefix.join(suffix), equalTo(new Parameter("prefix.suffix")));
+    }
 }

--- a/src/test/java/com/statemachinesystems/envy/features/PrefixTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/PrefixTest.java
@@ -1,0 +1,83 @@
+package com.statemachinesystems.envy.features;
+
+import com.statemachinesystems.envy.Name;
+import com.statemachinesystems.envy.Prefix;
+import com.statemachinesystems.envy.common.FeatureTest;
+import com.statemachinesystems.envy.common.StubConfigSource;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PrefixTest extends FeatureTest {
+
+    @Prefix("xxx")
+    @SuppressWarnings("unused")
+    interface A {
+        int inherited();
+
+        @Name("custom.name.inherited")
+        int inheritedWithCustomName();
+
+        @Name("xxx")
+        int customNameOverridden();
+
+        @Name("xxx")
+        int customNameRemoved();
+    }
+
+    @Prefix("custom.prefix")
+    interface B extends A {
+
+        int plain();
+
+        @Name("custom.name")
+        int withCustomName();
+
+        @Name("overridden.custom.name")
+        int customNameOverridden();
+
+        int customNameRemoved();
+    }
+
+    @Override
+    protected StubConfigSource configSource() {
+        return super.configSource()
+                .add("custom.prefix.plain", "1")
+                .add("custom.prefix.custom.name", "2")
+                .add("custom.prefix.inherited", "3")
+                .add("custom.prefix.custom.name.inherited", "4")
+                .add("custom.prefix.overridden.custom.name", "5")
+                .add("custom.prefix.custom.name.removed", "6");
+    }
+
+    @Test
+    public void appliesPrefixToPlainMethod() {
+        assertThat(envy().proxy(B.class).plain(), is(1));
+    }
+
+    @Test
+    public void appliesPrefixToMethodWithCustomName() {
+        assertThat(envy().proxy(B.class).withCustomName(), is(2));
+    }
+
+    @Test
+    public void appliesPrefixToInheritedMethod() {
+        assertThat(envy().proxy(B.class).inherited(), is(3));
+    }
+
+    @Test
+    public void appliesPrefixToInheritedMethodWithCustomName() {
+        assertThat(envy().proxy(B.class).inheritedWithCustomName(), is(4));
+    }
+
+    @Test
+    public void appliesPrefixToInheritedMethodWithOverriddenCustomName() {
+        assertThat(envy().proxy(B.class).customNameOverridden(), is(5));
+    }
+
+    @Test
+    public void appliesPrefixToInheritedMethodWithCustomNameRemoved() {
+        assertThat(envy().proxy(B.class).customNameRemoved(), is(6));
+    }
+}


### PR DESCRIPTION
Add a `@Prefix` annotation to support long environment variable prefixes without having to use the full name in the method or a `@Name` annotation.