### PR TITLE
Parse Optional types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
         <guava.version>19.0</guava.version>
+        <scala.library.version>2.11.8</scala.library.version>
         <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.17</maven.surefire.plugin.version>
         <maven.release.plugin.version>2.5.1</maven.release.plugin.version>
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.8</version>
+            <version>${scala.library.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -86,9 +87,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <source>${java.source.version}</source>
+                            <target>${java.target.version}</target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <source>${test.source.version}</source>
+                            <target>${test.target.version}</target>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
-                    <source>${java.source.version}</source>
-                    <target>${java.target.version}</target>
+                    <testExcludes>
+                        <testExclude>${excluded.test.pattern}</testExclude>
+                    </testExcludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -106,6 +124,7 @@
                             <argLine>${jacocoAgentConfigArgs}</argLine>
                             <excludes>
                                 <exclude>**/integration/*.*</exclude>
+                                <exclude>${excluded.test.pattern}</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -210,18 +229,33 @@
             <activation>
                 <jdk>1.6</jdk>
             </activation>
+            <properties>
+                <test.source.version>1.6</test.source.version>
+                <test.target.version>1.6</test.target.version>
+                <excluded.test.pattern>**/Java8*.*</excluded.test.pattern>
+            </properties>
         </profile>
         <profile>
             <id>jdk-1.7</id>
             <activation>
                 <jdk>1.7</jdk>
             </activation>
+            <properties>
+                <test.source.version>1.6</test.source.version>
+                <test.target.version>1.7</test.target.version>
+                <excluded.test.pattern>**/Java8*.*</excluded.test.pattern>
+            </properties>
         </profile>
         <profile>
             <id>jdk-1.8</id>
             <activation>
                 <jdk>1.8</jdk>
             </activation>
+            <properties>
+                <test.source.version>1.6</test.source.version>
+                <test.target.version>1.8</test.target.version>
+                <excluded.test.pattern>none</excluded.test.pattern>
+            </properties>
         </profile>
         <profile>
             <id>release-sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.11.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <properties>
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
+        <guava.version>19.0</guava.version>
         <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.17</maven.surefire.plugin.version>
         <maven.release.plugin.version>2.5.1</maven.release.plugin.version>
@@ -63,6 +64,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/statemachinesystems/envy/OptionalWrapper.java
+++ b/src/main/java/com/statemachinesystems/envy/OptionalWrapper.java
@@ -1,0 +1,89 @@
+package com.statemachinesystems.envy;
+
+import java.lang.reflect.*;
+
+public class OptionalWrapper {
+
+    private static class Invoker {
+        private final String className;
+        private final String methodName;
+
+        public Invoker(String className, String methodName) {
+            this.className = className;
+            this.methodName = methodName;
+        }
+
+        private boolean supports(Class<?> c) {
+            return className.equals(c.getName());
+        }
+
+        public Object create(Object object) throws Exception {
+            return Class.forName(className)
+                    .getMethod(methodName, Object.class)
+                    .invoke(null, object);
+        }
+    }
+
+    private static final Invoker[] INVOKERS = {
+            new Invoker("com.google.common.base.Optional", "fromNullable")
+    };
+
+    public static OptionalWrapper wrapperOrNull(Class<?> propertyClass, Method method) {
+        Invoker invoker = invokerOrNull(propertyClass);
+        return invoker != null
+                ? new OptionalWrapper(invoker, extractPropertyClass(method.getGenericReturnType()))
+                : null;
+    }
+
+    public static boolean isWrapperType(Class<?> propertyClass) {
+        return invokerOrNull(propertyClass) != null;
+    }
+
+    private static Invoker invokerOrNull(Class<?> propertyClass) {
+        for (Invoker invoker : INVOKERS) {
+            if (invoker.supports(propertyClass)) {
+                return invoker;
+            }
+        }
+        return null;
+    }
+
+    private static Class<?> extractPropertyClass(Type type) {
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        Type propertyType = parameterizedType.getActualTypeArguments()[0];
+
+        if (propertyType instanceof Class) {
+            return (Class<?>) propertyType;
+        }
+
+        if (propertyType instanceof GenericArrayType) {
+            GenericArrayType arrayType = (GenericArrayType) propertyType;
+            Type componentType = arrayType.getGenericComponentType();
+            if (componentType instanceof Class) {
+                return Array.newInstance((Class<?>) componentType, 0).getClass();
+            }
+        }
+
+        throw new UnsupportedTypeException("Unsupported generic type " + type);
+    }
+
+    private final Invoker invoker;
+    private final Class<?> propertyClass;
+
+    public OptionalWrapper(Invoker invoker, Class<?> propertyClass) {
+        this.invoker = invoker;
+        this.propertyClass = propertyClass;
+    }
+
+    public Class<?> getPropertyClass() {
+        return propertyClass;
+    }
+
+    public Object wrap(Object object) {
+        try {
+            return invoker.create(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/statemachinesystems/envy/OptionalWrapper.java
+++ b/src/main/java/com/statemachinesystems/envy/OptionalWrapper.java
@@ -25,6 +25,7 @@ public class OptionalWrapper {
     }
 
     private static final Invoker[] INVOKERS = {
+            new Invoker("java.util.Optional", "ofNullable"),
             new Invoker("scala.Option", "apply"),
             new Invoker("com.google.common.base.Optional", "fromNullable")
     };

--- a/src/main/java/com/statemachinesystems/envy/OptionalWrapper.java
+++ b/src/main/java/com/statemachinesystems/envy/OptionalWrapper.java
@@ -25,6 +25,7 @@ public class OptionalWrapper {
     }
 
     private static final Invoker[] INVOKERS = {
+            new Invoker("scala.Option", "apply"),
             new Invoker("com.google.common.base.Optional", "fromNullable")
     };
 

--- a/src/test/java/com/statemachinesystems/envy/features/Java8OptionalWrapperTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/Java8OptionalWrapperTest.java
@@ -1,0 +1,40 @@
+package com.statemachinesystems.envy.features;
+
+import com.statemachinesystems.envy.Default;
+import com.statemachinesystems.envy.common.FeatureTest;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class Java8OptionalWrapperTest extends FeatureTest {
+
+    interface Java8Simple {
+        Optional<String> foo();
+    }
+
+    interface Java8WithDefault {
+        @Default("baz")
+        Optional<String> foo();
+    }
+
+    @Test
+    public void wrapsProvidedValueWithJava8Optional() {
+        Java8Simple Java8 = envy(configSource().add("foo", "bar")).proxy(Java8Simple.class);
+        assertThat(Java8.foo(), equalTo(Optional.of("bar")));
+    }
+
+    @Test
+    public void wrapsMissingValueWithJava8Optional() {
+        Java8Simple Java8 = envy().proxy(Java8Simple.class);
+        assertThat(Java8.foo(), equalTo(Optional.<String>empty()));
+    }
+
+    @Test
+    public void wrapsDefaultValueWithJava8Optional() {
+        Java8WithDefault Java8 = envy().proxy(Java8WithDefault.class);
+        assertThat(Java8.foo(), equalTo(Optional.of("baz")));
+    }
+}

--- a/src/test/java/com/statemachinesystems/envy/features/OptionalWrapperTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/OptionalWrapperTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
-public class OptionalWrappersTest extends FeatureTest {
+public class OptionalWrapperTest extends FeatureTest {
 
     interface GuavaSimple {
         Optional<String> foo();

--- a/src/test/java/com/statemachinesystems/envy/features/OptionalWrappersTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/OptionalWrappersTest.java
@@ -1,0 +1,134 @@
+package com.statemachinesystems.envy.features;
+
+import com.google.common.base.Optional;
+import com.statemachinesystems.envy.Default;
+import com.statemachinesystems.envy.UnsupportedTypeException;
+import com.statemachinesystems.envy.common.FeatureTest;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+
+public class OptionalWrappersTest extends FeatureTest {
+
+    interface GuavaSimple {
+        Optional<String> foo();
+    }
+
+    interface GuavaWithDefault {
+        @Default("baz")
+        Optional<String> foo();
+    }
+
+    interface GuavaWithAnnotation {
+        @com.statemachinesystems.envy.Optional
+        Optional<Integer> foo();
+    }
+
+    interface GuavaWithArray {
+        Optional<Integer[]> foo();
+    }
+
+    interface GuavaWithPrimitiveArray {
+        Optional<int[]> foo();
+    }
+
+    interface GuavaWithNested {
+        interface Nested {
+            String bar();
+        }
+        Optional<Nested> foo();
+    }
+
+    interface GuavaWithArrayOfOptional {
+        Optional<String>[] foo();
+    }
+
+    interface GuavaWithOptionalOptional {
+        Optional<Optional<String>> foo();
+    }
+
+    interface GuavaWithWildcard {
+        Optional<? extends CharSequence> foo();
+    }
+
+    interface GuavaWithArrayOfGenericType {
+        <T> Optional<T[]> foo();
+    }
+
+    @Test
+    public void wrapsProvidedValueWithGuavaOptional() {
+        GuavaSimple guava = envy(configSource().add("foo", "bar")).proxy(GuavaSimple.class);
+        assertThat(guava.foo(), equalTo(Optional.of("bar")));
+    }
+
+    @Test
+    public void wrapsMissingValueWithGuavaOptional() {
+        GuavaSimple guava = envy().proxy(GuavaSimple.class);
+        assertThat(guava.foo(), equalTo(Optional.<String>absent()));
+    }
+
+    @Test
+    public void wrapsDefaultValueWithGuavaOptional() {
+        GuavaWithDefault guava = envy().proxy(GuavaWithDefault.class);
+        assertThat(guava.foo(), equalTo(Optional.of("baz")));
+    }
+
+    @Test
+    public void optionalAnnotationHasNoEffectForPresentValue() {
+        GuavaWithAnnotation guava = envy(configSource().add("foo", "1")).proxy(GuavaWithAnnotation.class);
+        assertThat(guava.foo(), equalTo(Optional.of(1)));
+    }
+
+    @Test
+    public void optionalAnnotationHasNoEffectForAbsentValue() {
+        GuavaWithAnnotation guava = envy().proxy(GuavaWithAnnotation.class);
+        assertThat(guava.foo(), equalTo(Optional.<Integer>absent()));
+    }
+
+    @Test
+    public void wrapsArray() {
+        GuavaWithArray guava = envy(configSource().add("foo", "1,2,3")).proxy(GuavaWithArray.class);
+        assertArrayEquals(new Integer[] { 1, 2, 3 }, guava.foo().get());
+    }
+
+    @Test
+    public void wrapsPrimitiveArray() {
+        GuavaWithPrimitiveArray guava = envy(configSource().add("foo", "1,2,3")).proxy(GuavaWithPrimitiveArray.class);
+        assertArrayEquals(new int[] { 1, 2, 3 }, guava.foo().get());
+
+    }
+
+    @Test
+    public void wrapsProvidedNestedValue() {
+        GuavaWithNested guava = envy(configSource().add("foo.bar", "baz")).proxy(GuavaWithNested.class);
+        assertThat(guava.foo().get().bar(), equalTo("baz"));
+    }
+
+    @Test
+    public void wrapsMissingNestedValue() {
+        GuavaWithNested guava = envy().proxy(GuavaWithNested.class);
+        assertThat(guava.foo(), equalTo(Optional.<GuavaWithNested.Nested>absent()));
+    }
+
+    @Test(expected = UnsupportedTypeException.class)
+    public void rejectsArrayOfOptionalValues() {
+        envy().proxy(GuavaWithArrayOfOptional.class);
+    }
+
+    @Test(expected = UnsupportedTypeException.class)
+    public void rejectsOptionalOptional() {
+        envy().proxy(GuavaWithOptionalOptional.class);
+    }
+
+    @Test(expected = UnsupportedTypeException.class)
+    public void rejectsWildcard() {
+        envy().proxy(GuavaWithWildcard.class);
+    }
+
+    @Test(expected = UnsupportedTypeException.class)
+    public void rejectsGenericArray() {
+        envy().proxy(GuavaWithArrayOfGenericType.class);
+    }
+}

--- a/src/test/java/com/statemachinesystems/envy/features/OptionalWrappersTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/OptionalWrappersTest.java
@@ -5,6 +5,7 @@ import com.statemachinesystems.envy.Default;
 import com.statemachinesystems.envy.UnsupportedTypeException;
 import com.statemachinesystems.envy.common.FeatureTest;
 import org.junit.Test;
+import scala.Option;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
@@ -16,9 +17,18 @@ public class OptionalWrappersTest extends FeatureTest {
         Optional<String> foo();
     }
 
+    interface ScalaSimple {
+        Option<String> foo();
+    }
+
     interface GuavaWithDefault {
         @Default("baz")
         Optional<String> foo();
+    }
+
+    interface ScalaWithDefault {
+        @Default("baz")
+        Option<String> foo();
     }
 
     interface GuavaWithAnnotation {
@@ -73,6 +83,24 @@ public class OptionalWrappersTest extends FeatureTest {
     public void wrapsDefaultValueWithGuavaOptional() {
         GuavaWithDefault guava = envy().proxy(GuavaWithDefault.class);
         assertThat(guava.foo(), equalTo(Optional.of("baz")));
+    }
+
+    @Test
+    public void wrapsProvidedValueWithScalaOption() {
+        ScalaSimple scala = envy(configSource().add("foo", "bar")).proxy(ScalaSimple.class);
+        assertThat(scala.foo(), equalTo(Option.apply("bar")));
+    }
+
+    @Test
+    public void wrapsMissingValueWithScalaOption() {
+        ScalaSimple scala = envy().proxy(ScalaSimple.class);
+        assertThat(scala.foo(), equalTo(Option.<String>empty()));
+    }
+
+    @Test
+    public void wrapsDefaultValueWithScalaOption() {
+        ScalaWithDefault scala = envy().proxy(ScalaWithDefault.class);
+        assertThat(scala.foo(), equalTo(Option.apply("baz")));
     }
 
     @Test


### PR DESCRIPTION
Support `java.util.Optional` from Java 8, `scala.Option` and `com.google.common.base.Optional` from Guava.