### PR TITLE
Rename @Optional to @Nullable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
                     <testExcludes>
                         <testExclude>${excluded.test.pattern}</testExclude>
                     </testExcludes>
+                    <source>${java.source.version}</source>
+                    <target>${java.target.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/statemachinesystems/envy/ConfigExtractor.java
+++ b/src/main/java/com/statemachinesystems/envy/ConfigExtractor.java
@@ -29,7 +29,11 @@ public class ConfigExtractor {
     }
 
     private static boolean isMandatory(Method method) {
-        return (method.getReturnType().isPrimitive() || method.getAnnotation(Optional.class) == null)
+        @SuppressWarnings("deprecation")
+        boolean notAnnotated = method.getAnnotation(Nullable.class) == null
+                && method.getAnnotation(Optional.class) == null;
+
+        return (method.getReturnType().isPrimitive() || notAnnotated)
                 && ! OptionalWrapper.isWrapperType(method.getReturnType());
     }
 

--- a/src/main/java/com/statemachinesystems/envy/Nullable.java
+++ b/src/main/java/com/statemachinesystems/envy/Nullable.java
@@ -9,7 +9,6 @@ import java.lang.annotation.Target;
 /**
  * Marks a nullable return value of an accessor method in a configuration interface.
  */
-@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Optional {}
+public @interface Nullable {}

--- a/src/test/java/com/statemachinesystems/envy/ConfigExtractorTest.java
+++ b/src/test/java/com/statemachinesystems/envy/ConfigExtractorTest.java
@@ -27,9 +27,17 @@ public class ConfigExtractorTest {
         @Name("custom.parameter.name")
         String stringWithCustomName();
 
+        @Nullable
+        Integer nullable();
+
+        @Nullable
+        Integer missing();
+
+        @SuppressWarnings("deprecation")
         @Optional
         Integer optionalNonNull();
 
+        @SuppressWarnings("deprecation")
         @Optional
         Integer optionalNull();
 
@@ -37,9 +45,9 @@ public class ConfigExtractorTest {
     }
 
     @SuppressWarnings("unused")
-    public interface BadConfigCombiningOptionalWithPrimitive {
-        @Optional
-        int notOptional();
+    public interface BadConfigCombiningNullableWithPrimitive {
+        @Nullable
+        int notNullable();
     }
 
     @SuppressWarnings("unused")
@@ -66,7 +74,8 @@ public class ConfigExtractorTest {
                 .add("AN_ARRAY_OF_BOXED_INTEGERS", "7")
                 .add("AN_ARRAY_OF_PRIMITIVE_INTEGERS", "1,2,3")
                 .add("CUSTOM_PARAMETER_NAME", "bar")
-                .add("OPTIONAL_NON_NULL", "5")
+                .add("NULLABLE", "5")
+                .add("OPTIONAL_NON_NULL", "6")
                 .add("METHOD_WITH_OBJECT_RETURN_TYPE", "bar")
                 .add("INT_IN_SUB_INTERFACE", "37")
                 .add("INT_IN_SUB_SUB_INTERFACE", "98")
@@ -114,8 +123,18 @@ public class ConfigExtractorTest {
     }
 
     @Test
+    public void retrievesNullableValue() throws Throwable {
+        assertEquals(5, getValue("nullable"));
+    }
+
+    @Test
+    public void retrievesNullMissingValue() throws Throwable {
+        assertNull(getValue("missing"));
+    }
+
+    @Test
     public void retrievesOptionalNonNullValue() throws Throwable {
-        assertEquals(5, getValue("optionalNonNull"));
+        assertEquals(6, getValue("optionalNonNull"));
     }
 
     @Test
@@ -138,8 +157,8 @@ public class ConfigExtractorTest {
     }
 
     @Test(expected = MissingParameterValueException.class)
-    public void rejectsOptionalAnnotationWithPrimitiveReturnType() {
-        configExtractor.extractValuesByMethodName(BadConfigCombiningOptionalWithPrimitive.class);
+    public void rejectsNullableAnnotationWithPrimitiveReturnType() {
+        configExtractor.extractValuesByMethodName(BadConfigCombiningNullableWithPrimitive.class);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/statemachinesystems/envy/features/NestingTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/NestingTest.java
@@ -31,7 +31,7 @@ public class NestingTest extends FeatureTest {
             int bar();
             int baz();
         }
-        @Optional
+        @Nullable
         Inner3 foo();
     }
 
@@ -39,10 +39,10 @@ public class NestingTest extends FeatureTest {
         interface Inner4 {
             int bar();
 
-            @Optional
+            @Nullable
             String baz();
         }
-        @Optional
+        @Nullable
         Inner4 foo();
     }
 
@@ -98,7 +98,7 @@ public class NestingTest extends FeatureTest {
     }
 
     @Test
-    public void optionalNestedConfigWithAllValuesProvidedIsPopulated() {
+    public void nullableNestedConfigWithAllValuesProvidedIsPopulated() {
         ConfigSource configSource = configSource().add("foo.bar", "1").add("foo.baz", "2");
         Outer3 config = envy(configSource).proxy(Outer3.class);
         assertThat(config.foo().bar(), equalTo(1));
@@ -106,20 +106,20 @@ public class NestingTest extends FeatureTest {
     }
 
     @Test
-    public void optionalNestedConfigWithNoValuesProvidedIsNull() {
+    public void nullableNestedConfigWithNoValuesProvidedIsNull() {
         Outer3 config = envy().proxy(Outer3.class);
         assertThat(config.foo(), nullValue());
     }
 
     @Test
-    public void optionalNestedConfigWithSomeValuesProvidedIsNull() {
+    public void nullableNestedConfigWithSomeValuesProvidedIsNull() {
         ConfigSource configSource = configSource().add("foo.bar", "1");
         Outer3 config = envy(configSource).proxy(Outer3.class);
         assertThat(config.foo(), nullValue());
     }
 
     @Test
-    public void optionalNestedConfigWithAllMandatoryValuesProvidedIsPopulated() {
+    public void nullableNestedConfigWithAllMandatoryValuesProvidedIsPopulated() {
         ConfigSource configSource = configSource().add("foo.bar", "1");
         Outer4 config = envy(configSource).proxy(Outer4.class);
         assertThat(config.foo().bar(), equalTo(1));

--- a/src/test/java/com/statemachinesystems/envy/features/OptionalWrapperTest.java
+++ b/src/test/java/com/statemachinesystems/envy/features/OptionalWrapperTest.java
@@ -2,6 +2,7 @@ package com.statemachinesystems.envy.features;
 
 import com.google.common.base.Optional;
 import com.statemachinesystems.envy.Default;
+import com.statemachinesystems.envy.Nullable;
 import com.statemachinesystems.envy.UnsupportedTypeException;
 import com.statemachinesystems.envy.common.FeatureTest;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class OptionalWrapperTest extends FeatureTest {
     }
 
     interface GuavaWithAnnotation {
-        @com.statemachinesystems.envy.Optional
+        @Nullable
         Optional<Integer> foo();
     }
 
@@ -104,13 +105,13 @@ public class OptionalWrapperTest extends FeatureTest {
     }
 
     @Test
-    public void optionalAnnotationHasNoEffectForPresentValue() {
+    public void nullableAnnotationHasNoEffectForPresentValue() {
         GuavaWithAnnotation guava = envy(configSource().add("foo", "1")).proxy(GuavaWithAnnotation.class);
         assertThat(guava.foo(), equalTo(Optional.of(1)));
     }
 
     @Test
-    public void optionalAnnotationHasNoEffectForAbsentValue() {
+    public void nullableAnnotationHasNoEffectForAbsentValue() {
         GuavaWithAnnotation guava = envy().proxy(GuavaWithAnnotation.class);
         assertThat(guava.foo(), equalTo(Optional.<Integer>absent()));
     }

--- a/src/test/java/com/statemachinesystems/envy/integration/EnvyIntegrationTest.java
+++ b/src/test/java/com/statemachinesystems/envy/integration/EnvyIntegrationTest.java
@@ -27,7 +27,7 @@ public class EnvyIntegrationTest {
         @Name("com.foo.long.and.awkward.name")
         String withCustomName();
 
-        @Optional
+        @Nullable
         String mightBeNull();
 
         Object objectType();
@@ -93,7 +93,7 @@ public class EnvyIntegrationTest {
     }
 
     @Test
-    public void returnsNullForUndefinedOptionalParameter() {
+    public void returnsNullForUndefinedNullableParameter() {
         assertNull(config.mightBeNull());
     }
 


### PR DESCRIPTION
Using `Optional` (Java 8 or Guava) and `@Optional` in the same class is very painful. Really, the annotation is conveying that the return value might be null.

Unfortunately the various `@Nullable` annotations available in the wild aren't retained at runtime, so can't be detected via reflection.

Instead, deprecate the existing `@Optional` annotation and add a `@Nullable` one for the same purpose.