### PR TITLE
Trailing capitals in property names should be treated as separate words

### DIFF
--- a/src/main/java/com/statemachinesystems/envy/PropertyNameParser.java
+++ b/src/main/java/com/statemachinesystems/envy/PropertyNameParser.java
@@ -14,7 +14,7 @@ import static java.lang.Character.isUpperCase;
  */
 public class PropertyNameParser {
 
-    private static enum ParserState {
+    private enum ParserState {
         INITIAL, ACCUMULATING, ACCUMULATING_WITH_INITIAL_CAPS
     }
 
@@ -86,6 +86,7 @@ public class PropertyNameParser {
                 case ACCUMULATING_WITH_INITIAL_CAPS:
                     if (isLowerCase(ch)) {
                         buffer(ch);
+                        state = ParserState.ACCUMULATING;
                     } else if (isUpperCase(ch)) {
                         int lookahead = reader.read();
                         if (isLowerCase(lookahead)) {
@@ -98,7 +99,8 @@ public class PropertyNameParser {
                             buffer(ch);
                         }
                     } else if (isDigit(ch)) {
-                         buffer(ch);
+                        buffer(ch);
+                        state = ParserState.ACCUMULATING;
                     } else if (isEof(ch)) {
                         emit();
                         return parts;

--- a/src/test/java/com/statemachinesystems/envy/ParameterTest.java
+++ b/src/test/java/com/statemachinesystems/envy/ParameterTest.java
@@ -70,6 +70,26 @@ public class ParameterTest {
         assertThat(Parameter.fromMethodName("HTTP11Proxy"), equalTo(new Parameter("http11.proxy")));
     }
 
+    @Test
+    public void createsParameterWithTrailingSingleCapitalLetter() {
+        assertThat(Parameter.fromMethodName("LogN"), equalTo(new Parameter("log.n")));
+    }
+
+    @Test
+    public void createsParameterWithTrailingSingleDigit() {
+        assertThat(Parameter.fromMethodName("Log2"), equalTo(new Parameter("log2")));
+    }
+
+    @Test
+    public void createsParameterWithTrailingDigits() {
+        assertThat(Parameter.fromMethodName("Log10"), equalTo(new Parameter("log10")));
+    }
+
+    @Test
+    public void createsParameterWithDigitsInMiddleOfWordFollowedByCaps() {
+        assertThat(Parameter.fromMethodName("X10AThing"), equalTo(new Parameter("x10.a.thing")));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void rejectsEmptyMethodName() {
         Parameter.fromMethodName("");


### PR DESCRIPTION
    trait C {
      def logLogN: Int
    }
    Envy.configure(classOf[C])
For the above snippet Envy reports `Missing configuration parameter value for LOG_LOGN in C.logLogN`, ignoring the value of `LOG_LOG_N`.

This is the case for any number of trailing uppercase letters, so `logLogMEIN` translates to parameter value `LOG_LOGMEIN` but should probably be `LOG_LOG_M_E_I_N`.