### PR TITLE
Durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Envy will do the following type conversions for you:
 * `java.net.InetAddress`, `Inet4Address`, `Inet6Address`, `InetSocketAddress`
 * `java.util.regex.Pattern`
 * `java.util.UUID`
+* `java.time.Duration` using a flexible format (e.g. "100ms", "30 seconds")
 
 ### Custom data types
 

--- a/src/main/java/com/statemachinesystems/envy/Envy.java
+++ b/src/main/java/com/statemachinesystems/envy/Envy.java
@@ -60,6 +60,7 @@ public class Envy {
         valueParsers.add(new CharacterValueParser());
         valueParsers.add(new ClassValueParser());
         valueParsers.add(new DoubleValueParser());
+        valueParsers.add(new DurationValueParser());
         valueParsers.add(new FileValueParser());
         valueParsers.add(new FloatValueParser());
         valueParsers.add(new InetAddressValueParser());

--- a/src/main/java/com/statemachinesystems/envy/parsers/DurationValueParser.java
+++ b/src/main/java/com/statemachinesystems/envy/parsers/DurationValueParser.java
@@ -1,0 +1,81 @@
+package com.statemachinesystems.envy.parsers;
+
+import com.statemachinesystems.envy.ValueParser;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * {@link ValueParser} implementation for {@link java.time.Duration} values.
+ *
+ * <p>Supports the following grammar:</p>
+ * <pre>
+ *     ("-"|"+")? digit+ whitespace? label
+ * </pre>
+ *
+ * Where <code>label</code> must be one of the following lower-case values:
+ * <ul>
+ *     <li><code>d</code>, <code>day</code> or <code>days</code></li>
+ *     <li><code>h</code>, <code>hour</code> or <code>hours</code></li>
+ *     <li><code>m</code>, <code>min</code>, <code>mins</code>, <code>minute</code> or <code>minutes</code></li>
+ *     <li><code>s</code>, <code>sec</code>, <code>secs</code>, <code>second</code> or <code>seconds</code></li>
+ *     <li><code>ms</code>, <code>milli</code>, <code>millis</code>, <code>millisecond</code> or <code>milliseconds</code></li>
+ *     <li><code>us</code>, <code>&mu;s</code>, <code>micro</code>, <code>micros</code>, <code>microsecond</code> or <code>microsecond</code></li>
+ *     <li><code>ns</code>, <code>nano</code>, <code>nanos</code>, <code>nanosecond</code> or <code>nanoseconds</code></li>
+ * </ul>
+ */
+public class DurationValueParser implements ValueParser<Duration> {
+
+    private static Pattern pattern = Pattern.compile("([-+]?\\d+)\\s*(\\p{Lower}+)", Pattern.UNICODE_CHARACTER_CLASS);
+
+    private static Map<String, TemporalUnit> units = new HashMap<>();
+
+    static {
+        for (String label : new String[] {"d", "day", "days"}) {
+            units.put(label, ChronoUnit.DAYS);
+        }
+        for (String label : new String[] {"h", "hour", "hours"}) {
+            units.put(label, ChronoUnit.HOURS);
+        }
+        for (String label : new String[] {"m", "min", "mins", "minute", "minutes"}) {
+            units.put(label, ChronoUnit.MINUTES);
+        }
+        for (String label : new String[] {"s", "sec", "secs", "second", "seconds"}) {
+            units.put(label, ChronoUnit.SECONDS);
+        }
+        for (String label : new String[] {"ms", "milli", "millis", "millisecond", "milliseconds"}) {
+            units.put(label, ChronoUnit.MILLIS);
+        }
+        for (String label : new String[] {"us", "\u03BCs", "micro", "micros", "microsecond", "microseconds"}) {
+            units.put(label, ChronoUnit.MICROS);
+        }
+        for (String label : new String[] {"ns", "nano", "nanos", "nanosecond", "nanoseconds"}) {
+            units.put(label, ChronoUnit.NANOS);
+        }
+    }
+
+    @Override
+    public Duration parseValue(String value) {
+        Matcher matcher = pattern.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid duration format: " + value);
+        }
+        // TODO sign
+        long amount = Long.parseLong(matcher.group(1));
+        TemporalUnit unit = units.get(matcher.group(2));
+        if (unit == null) {
+            throw new IllegalArgumentException("Invalid duration unit: " + matcher.group(2));
+        }
+        return Duration.of(amount, unit);
+    }
+
+    @Override
+    public Class<Duration> getValueClass() {
+        return Duration.class;
+    }
+}

--- a/src/test/java/com/statemachinesystems/envy/parsers/DurationValueParserTest.java
+++ b/src/test/java/com/statemachinesystems/envy/parsers/DurationValueParserTest.java
@@ -1,0 +1,121 @@
+package com.statemachinesystems.envy.parsers;
+
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.time.Duration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DurationValueParserTest {
+
+    private final DurationValueParser parser = new DurationValueParser();
+
+    @Test
+    public void parsesDurationInDays() {
+        String[] variants = {"6d", "6 day", "6 days"};
+        Duration expected = Duration.ofDays(6);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesDurationInHours() {
+        String[] variants = {"12h", "12 hour", "12 hours"};
+        Duration expected = Duration.ofHours(12);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesDurationInMinutes() {
+        String[] variants = {"58m", "58 min", "58 mins", "58 minute", "58 minutes"};
+        Duration expected = Duration.ofMinutes(58);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesDurationInSeconds() {
+        String[] variants = {"1s", "1 sec", "1 secs", "1 second", "1 seconds"};
+        Duration expected = Duration.ofSeconds(1);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesDurationInMilliseconds() {
+        String[] variants = {"213ms", "213 milli", "213 millis", "213 millisecond", "213 milliseconds"};
+        Duration expected = Duration.ofMillis(213);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesDurationInMicroseconds() {
+        String[] variants = {"12345us", "12345\u03BCs", "12345 micro", "12345 micros", "12345 microsecond", "12345 microseconds"};
+        Duration expected = Duration.ofNanos(12_345_000);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesDurationInNanoSeconds() {
+        String[] variants = {"67890ns", "67890 nano", "67890 nanos", "67890 nanosecond", "67890 nanoseconds"};
+        Duration expected = Duration.ofNanos(67890);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesNegativeDurations() {
+        String[] variants = {"-10s", "-10 seconds"};
+        Duration expected = Duration.ofSeconds(-10);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test
+    public void parsesExplicitlyPositiveDurations() {
+        String[] variants = {"+100ms", "+100 millis"};
+        Duration expected = Duration.ofMillis(100);
+        for (String value : variants) {
+            assertThat(parser.parseValue(value), is(expected));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsEmptyString() {
+        parser.parseValue("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingUnit() {
+        parser.parseValue("5");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingAmount() {
+        parser.parseValue("seconds");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void rejectsOutOfRangeAmount() {
+        BigInteger outOfRange = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        parser.parseValue(outOfRange + "ns");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsUnknownUnit() {
+        parser.parseValue("18xx");
+    }
+}


### PR DESCRIPTION
Parse to `java.time.Duration` (and `scala.concurrent.duration.Duration`).

Something like [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md#duration-format)'s format would be useful.